### PR TITLE
Basic Admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,33 @@ for each file:
 - Size
 - Owner ID
 
+#### Logging
+
+Endpoints beginning with `/api/...` should be monitored for error codes to prevent bruteforcing.
+
+For example:
+
+- `/login` is the endpoint for the login web page, this only loads static content
+    - This will always return a `200` response, since there is nothing sensitive about loading
+      the login page.
+- `/api/login` is the endpoint for submitting credentials
+    - This can return an error code depending on the failure (i.e. `403` for invalid credentials,
+      `404` for a non-existent user, etc)
+
+You can limit requests to all `/api` endpoints in a Nginx config, for example, with something like
+this:
+
+```nginx
+limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/m;
+
+// ...
+
+location /api/ {
+    limit_req zone=api_limit burst=20 nodelay;
+    proxy_pass http://backend;
+}
+```
+
 ## CLI Configuration
 
 The YeetFile CLI tool can be configured using a `config.yml` file in the following path:
@@ -251,6 +278,9 @@ All environment variables can be defined in a file named `.env` at the root leve
 | YEETFILE_CACHE_MAX_FILE_SIZE | The maximum file size to cache | 0 | An int value of bytes |
 | YEETFILE_TLS_KEY | The SSL key to use for connections | | The string key contents (not a file path) |
 | YEETFILE_TLS_CERT | The SSL cert to use for connections | | The string cert contents (not a file path) |
+| YEETFILE_INSTANCE_ADMIN | The user ID or email of the user to set as admin | | A valid YeetFile email or account ID |
+| YEETFILE_LIMITER_SECONDS | The number of seconds to use in rate limiting repeated requests | 30 | Any number of seconds |
+| YEETFILE_LIMITER_ATTEMPTS | The number of attempts to allow before rate limiting | 6 | Any number of requests |
 
 #### Backblaze Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Contents
     - [Access](#access)
     - [Email Registration](#email-registration)
     - [Administration](#administration)
+    - [Logging](#logging)
 1. [CLI Configuration](#cli-configuration)
 1. [Development](#development)
     1. [Requirements](#requirements)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Contents
 1. [Self-Hosting](#self-hosting)
     - [Access](#access)
     - [Email Registration](#email-registration)
+    - [Administration](#administration)
 1. [CLI Configuration](#cli-configuration)
 1. [Development](#development)
     1. [Requirements](#requirements)
@@ -126,7 +127,7 @@ If you need to access the web interface using a machine IP on your network, for 
 generate a cert and set the `YEETFILE_TLS_CERT` and `YEETFILE_TLS_KEY` environment variables (see
 [Environment Variables](#environment-variables))
 
-> [!NOTE]  
+> [!NOTE]
 > This does not apply to the CLI tool. You can still use all features of YeetFile from the CLI tool
 > without a secure connection.
 
@@ -152,6 +153,21 @@ YEETFILE_EMAIL_USER=...
 YEETFILE_EMAIL_PASSWORD=...
 ```
 
+#### Administration
+
+You can declare yourself as the admin of your instance by setting the
+`YEETFILE_INSTANCE_ADMIN` environment variable to your YeetFile account ID or
+email address.
+
+This will allow you to manage users and their files on the instance. Note that
+file names are encrypted, but you will be able to see the following metadata
+for each file:
+
+- File ID
+- Last Modified
+- Size
+- Owner ID
+
 ## CLI Configuration
 
 The YeetFile CLI tool can be configured using a `config.yml` file in the following path:
@@ -173,7 +189,7 @@ default_view: "vault"
 # debug_file: "~/.config/yeetfile/debug.log"
 ```
 
-You can change the `server` directive to your own instance of YeetFile. 
+You can change the `server` directive to your own instance of YeetFile.
 
 ## Development
 

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -38,6 +38,8 @@ var TLSKey = utils.GetEnvVar("YEETFILE_TLS_KEY", "")
 
 var IsDebugMode = utils.GetEnvVarBool("YEETFILE_DEBUG", false)
 
+var InstanceAdmin = utils.GetEnvVar("YEETFILE_INSTANCE_ADMIN", "")
+
 // =============================================================================
 // Email configuration (used in account verification and billing reminders)
 // =============================================================================

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -32,6 +32,8 @@ var secret = utils.GetEnvVarBytesB64("YEETFILE_SERVER_SECRET", defaultSecret)
 var fallbackWebSecret = utils.GetEnvVarBytesB64(
 	"YEETFILE_FALLBACK_WEB_SECRET",
 	securecookie.GenerateRandomKey(32))
+var limiterSeconds = utils.GetEnvVarInt("YEETFILE_LIMITER_SECONDS", 30)
+var limiterAttempts = utils.GetEnvVarInt("YEETFILE_LIMITER_ATTEMPTS", 6)
 
 var TLSCert = utils.GetEnvVar("YEETFILE_TLS_CERT", "")
 var TLSKey = utils.GetEnvVar("YEETFILE_TLS_KEY", "")
@@ -112,6 +114,8 @@ type ServerConfig struct {
 	PasswordHash        []byte
 	ServerSecret        []byte
 	FallbackWebSecret   []byte
+	LimiterSeconds      int
+	LimiterAttempts     int
 }
 
 type TemplateConfig struct {
@@ -166,6 +170,8 @@ func init() {
 		PasswordHash:        passwordHash,
 		ServerSecret:        secret,
 		FallbackWebSecret:   fallbackWebSecret,
+		LimiterSeconds:      limiterSeconds,
+		LimiterAttempts:     limiterAttempts,
 	}
 
 	// Subset of main server config to use in HTML templating

--- a/backend/db/cron.go
+++ b/backend/db/cron.go
@@ -46,7 +46,7 @@ var tasks = []CronTask{
 	{
 		Name:           LimiterTask,
 		Interval:       time.Second,
-		IntervalAmount: constants.LimiterSeconds,
+		IntervalAmount: config.YeetFileConfig.LimiterSeconds,
 		Enabled:        true,
 		TaskFn:         func() {}, // Set in InitCronTasks
 	},

--- a/backend/db/expiry.go
+++ b/backend/db/expiry.go
@@ -11,14 +11,12 @@ type FileExpiry struct {
 	Date      time.Time
 }
 
-func SetFileExpiry(id string, downloads int, date time.Time) {
+func SetFileExpiry(id string, downloads int, date time.Time) error {
 	s := `INSERT INTO expiry
 	      (id, downloads, date)
 	      VALUES ($1, $2, $3)`
 	_, err := db.Exec(s, id, downloads, date)
-	if err != nil {
-		panic(err)
-	}
+	return err
 }
 
 func DecrementDownloads(id string) int {

--- a/backend/db/scripts/migrations/4_add_admin.sql
+++ b/backend/db/scripts/migrations/4_add_admin.sql
@@ -1,0 +1,1 @@
+alter table users add admin bool default false;

--- a/backend/db/scripts/migrations/4_add_admin.sql
+++ b/backend/db/scripts/migrations/4_add_admin.sql
@@ -1,1 +1,0 @@
-alter table users add admin bool default false;

--- a/backend/db/scripts/migrations/4_send_metadata.sql
+++ b/backend/db/scripts/migrations/4_send_metadata.sql
@@ -1,0 +1,5 @@
+ALTER TABLE metadata ADD COLUMN owner_id text DEFAULT '';
+UPDATE metadata SET owner_id = '';
+
+ALTER TABLE metadata ADD COLUMN modified TIMESTAMP DEFAULT now();
+UPDATE metadata SET modified = now();

--- a/backend/db/users.go
+++ b/backend/db/users.go
@@ -958,6 +958,18 @@ func CheckUpgradeExpiration() {
 	}
 }
 
+func IsUserAdmin(id string) (bool, error) {
+	var isAdmin bool
+	s := `SELECT admin FROM users WHERE id=$1`
+	err := db.QueryRow(s, id).Scan(&isAdmin)
+
+	if err != nil {
+		return false, err
+	}
+
+	return isAdmin, nil
+}
+
 // ExpDateRollover checks to see if the user's upgrade expiration date takes
 // place on a day that doesn't exist in other months. If so, the user's transfer
 // limit should be upgraded "early". For example:

--- a/backend/db/vault.go
+++ b/backend/db/vault.go
@@ -350,6 +350,52 @@ func DeleteVaultFile(id, ownerID string) error {
 	return err
 }
 
+// AdminDeleteFile deletes an entry in the file vault regardless of owner
+func AdminDeleteFile(id string) error {
+	s := `DELETE FROM vault WHERE id=$1 OR ref_id=$1`
+	_, err := db.Exec(s, id)
+	return err
+}
+
+func AdminFetchFiles(userID string) ([]shared.AdminFileInfoResponse, error) {
+	response := []shared.AdminFileInfoResponse{}
+
+	s := `SELECT id, name, length, owner_id, modified FROM vault WHERE owner_id=$1`
+	rows, err := db.Query(s, userID)
+	if err != nil {
+		log.Printf("Error retrieving files: %v\n", err)
+		return response, err
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			id       string
+			name     string
+			length   int64
+			ownerID  string
+			modified time.Time
+		)
+
+		err = rows.Scan(&id, &name, &length, &ownerID, &modified)
+		if err != nil {
+			return response, err
+		}
+
+		response = append(response, shared.AdminFileInfoResponse{
+			ID:         id,
+			BucketName: name,
+			Size:       shared.ReadableFileSize(length),
+			OwnerID:    ownerID,
+			Modified:   modified,
+
+			RawSize: length,
+		})
+	}
+
+	return response, err
+}
+
 // DeleteSharedFile deletes a shared file from the recipient's vault
 func DeleteSharedFile(id, ownerID string) error {
 	s := `DELETE FROM vault WHERE id=$1 AND owner_id=$2 RETURNING ref_id`
@@ -437,6 +483,28 @@ func RetrieveFullItemInfo(id, ownerID string) (shared.VaultItemInfo, error) {
 		RefID:        "",
 		KeySequence:  keySequence,
 	}, nil
+}
+
+func AdminRetrieveMetadata(fileID string) (shared.AdminFileInfoResponse, error) {
+	var (
+		id       string
+		name     string
+		length   int64
+		ownerID  string
+		modified time.Time
+	)
+
+	s := `SELECT id, name, length, owner_id, modified FROM vault WHERE id=$1`
+	err := db.QueryRow(s, fileID).Scan(&id, &name, &length, &ownerID, &modified)
+	return shared.AdminFileInfoResponse{
+		ID:         id,
+		BucketName: name,
+		Size:       shared.ReadableFileSize(length),
+		OwnerID:    ownerID,
+		Modified:   modified,
+
+		RawSize: length,
+	}, err
 }
 
 // RetrieveVaultMetadata returns a FileMetadata struct containing a specific

--- a/backend/db/vault.go
+++ b/backend/db/vault.go
@@ -357,7 +357,8 @@ func AdminDeleteFile(id string) error {
 	return err
 }
 
-func AdminFetchFiles(userID string) ([]shared.AdminFileInfoResponse, error) {
+// AdminFetchVaultFiles fetches all files for a specific user
+func AdminFetchVaultFiles(userID string) ([]shared.AdminFileInfoResponse, error) {
 	response := []shared.AdminFileInfoResponse{}
 
 	s := `SELECT id, name, length, owner_id, modified FROM vault WHERE owner_id=$1`

--- a/backend/server/admin/file_actions.go
+++ b/backend/server/admin/file_actions.go
@@ -1,0 +1,50 @@
+package admin
+
+import (
+	"database/sql"
+	"log"
+	"yeetfile/backend/db"
+	"yeetfile/shared"
+)
+
+func deleteFile(fileID string) error {
+	metadata, err := db.AdminRetrieveMetadata(fileID)
+	if err == nil {
+		// Delete vault file
+		err = db.AdminDeleteFile(fileID)
+		if err != nil {
+			log.Printf("Error deleting file: %v\n", err)
+			return err
+		}
+
+		_ = db.UpdateStorageUsed(metadata.OwnerID, -metadata.RawSize)
+	} else {
+		// Attempt to delete Send file instead
+		metadata, err := db.RetrieveMetadata(fileID)
+		if err != nil {
+			return err
+		}
+
+		db.DeleteFileByMetadata(metadata)
+	}
+
+	return nil
+}
+
+func fetchFileMetadata(fileID string) (shared.AdminFileInfoResponse, error) {
+	fileInfo, err := db.AdminRetrieveMetadata(fileID)
+	if err != nil && err != sql.ErrNoRows {
+		return shared.AdminFileInfoResponse{}, err
+	} else if err == nil {
+		return fileInfo, nil
+	}
+
+	sendFileInfo, err := db.AdminRetrieveSendMetadata(fileID)
+	if err != nil && err != sql.ErrNoRows {
+		return shared.AdminFileInfoResponse{}, err
+	} else if err == nil {
+		return sendFileInfo, nil
+	}
+
+	return shared.AdminFileInfoResponse{}, err
+}

--- a/backend/server/admin/handlers.go
+++ b/backend/server/admin/handlers.go
@@ -1,0 +1,93 @@
+package admin
+
+import (
+	"database/sql"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"yeetfile/backend/db"
+	"yeetfile/shared"
+)
+
+func UserActionHandler(w http.ResponseWriter, req *http.Request, _ string) {
+	segments := strings.Split(req.URL.Path, "/")
+	userID := segments[len(segments)-1]
+
+	switch req.Method {
+	case http.MethodDelete:
+		err := deleteUser(userID)
+		if err != nil {
+			log.Printf("Error deleting user: %v\n", err)
+			http.Error(w, "Failed to delete user", http.StatusInternalServerError)
+			return
+		}
+	case http.MethodGet:
+		user, err := getUserInfo(userID)
+		if err != nil {
+			log.Printf("Error fetching user: %v\n", err)
+			if err == sql.ErrNoRows {
+				http.Error(w, "No match found", http.StatusNotFound)
+				return
+			}
+
+			http.Error(w, "Failed to fetch user info", http.StatusInternalServerError)
+			return
+		}
+
+		files, err := db.AdminFetchFiles(userID)
+		if err != nil {
+			log.Printf("Error fetching user files: %v\n", err)
+		}
+
+		userResponse := shared.AdminUserInfoResponse{
+			ID:          user.ID,
+			Email:       user.Email,
+			StorageUsed: shared.ReadableFileSize(user.StorageUsed),
+			SendUsed:    shared.ReadableFileSize(user.SendUsed),
+
+			Files: files,
+		}
+
+		_ = json.NewEncoder(w).Encode(userResponse)
+	}
+}
+
+func FileActionHandler(w http.ResponseWriter, req *http.Request, _ string) {
+	segments := strings.Split(req.URL.Path, "/")
+	fileID := segments[len(segments)-1]
+
+	switch req.Method {
+	case http.MethodDelete:
+		metadata, err := db.AdminRetrieveMetadata(fileID)
+		if err != nil {
+			log.Printf("Error fetching file: %v\n", err)
+			http.Error(w, "Failed to fetch file", http.StatusInternalServerError)
+			return
+		}
+
+		err = db.AdminDeleteFile(fileID)
+		if err != nil {
+			log.Printf("Error deleting file: %v\n", err)
+			http.Error(w, "Failed to delete file", http.StatusInternalServerError)
+			return
+		}
+
+		_ = db.UpdateStorageUsed(metadata.OwnerID, -metadata.RawSize)
+	case http.MethodGet:
+		fileInfo, err := db.AdminRetrieveMetadata(fileID)
+		if err != nil {
+			log.Printf("Error fetching file: %v\n", err)
+			if err == sql.ErrNoRows {
+				http.Error(w, "No match found", http.StatusNotFound)
+				return
+			}
+
+			http.Error(w, "Failed to fetch file info", http.StatusInternalServerError)
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(fileInfo)
+	}
+
+}

--- a/backend/server/admin/handlers.go
+++ b/backend/server/admin/handlers.go
@@ -10,9 +10,14 @@ import (
 	"yeetfile/shared"
 )
 
-func UserActionHandler(w http.ResponseWriter, req *http.Request, _ string) {
+func UserActionHandler(w http.ResponseWriter, req *http.Request, id string) {
 	segments := strings.Split(req.URL.Path, "/")
 	userID := segments[len(segments)-1]
+
+	if userID == id {
+		http.Error(w, "Cannot fetch yourself", http.StatusBadRequest)
+		return
+	}
 
 	switch req.Method {
 	case http.MethodDelete:

--- a/backend/server/admin/user_actions.go
+++ b/backend/server/admin/user_actions.go
@@ -1,0 +1,29 @@
+package admin
+
+import (
+	"strings"
+	"yeetfile/backend/db"
+	"yeetfile/backend/server/auth"
+	"yeetfile/shared"
+)
+
+func deleteUser(userID string) error {
+	return auth.DeleteUser(userID, shared.DeleteAccount{Identifier: userID})
+}
+
+func getUserInfo(userID string) (db.User, error) {
+	var err error
+	if strings.Contains(userID, "@") {
+		userID, err = db.GetUserIDByEmail(userID)
+		if err != nil {
+			return db.User{}, err
+		}
+	}
+
+	user, err := db.GetUserByID(userID)
+	if err != nil {
+		return db.User{}, err
+	}
+
+	return user, nil
+}

--- a/backend/server/admin/user_actions.go
+++ b/backend/server/admin/user_actions.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"log"
 	"strings"
 	"yeetfile/backend/db"
 	"yeetfile/backend/server/auth"
@@ -9,6 +10,28 @@ import (
 
 func deleteUser(userID string) error {
 	return auth.DeleteUser(userID, shared.DeleteAccount{Identifier: userID})
+}
+
+func fetchAllFiles(userID string) []shared.AdminFileInfoResponse {
+	if strings.Contains(userID, "@") {
+		userID, _ = db.GetUserIDByEmail(userID)
+	}
+
+	files := []shared.AdminFileInfoResponse{}
+	vaultFiles, err := db.AdminFetchVaultFiles(userID)
+	if err != nil {
+		log.Printf("Error fetching user files: %v\n", err)
+	}
+
+	files = append(files, vaultFiles...)
+
+	sendFiles, err := db.AdminFetchSentFiles(userID)
+	if err != nil {
+		log.Printf("Error fetching user send files: %v\n", err)
+	}
+
+	files = append(files, sendFiles...)
+	return files
 }
 
 func getUserInfo(userID string) (db.User, error) {

--- a/backend/server/auth/auth.go
+++ b/backend/server/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"log"
 	"strings"
+	"yeetfile/backend/config"
 	"yeetfile/backend/db"
 	"yeetfile/backend/server/transfer/vault"
 	"yeetfile/shared"
@@ -118,6 +119,19 @@ func updateUser(values db.VerifiedAccountValues) error {
 	}
 
 	return nil
+}
+
+func IsInstanceAdmin(currentUserID string) bool {
+	adminID := config.InstanceAdmin
+	if len(adminID) > 0 {
+		if strings.Contains(adminID, "@") {
+			adminID, _ = db.GetUserIDByEmail(currentUserID)
+		}
+
+		return adminID == currentUserID
+	}
+
+	return false
 }
 
 func DeleteUser(id string, deleteAccount shared.DeleteAccount) error {

--- a/backend/server/auth/auth.go
+++ b/backend/server/auth/auth.go
@@ -120,7 +120,7 @@ func updateUser(values db.VerifiedAccountValues) error {
 	return nil
 }
 
-func deleteUser(id string, deleteAccount shared.DeleteAccount) error {
+func DeleteUser(id string, deleteAccount shared.DeleteAccount) error {
 	accountID := deleteAccount.Identifier
 	var err error
 	if strings.Contains(deleteAccount.Identifier, "@") {

--- a/backend/server/auth/auth.go
+++ b/backend/server/auth/auth.go
@@ -125,7 +125,7 @@ func IsInstanceAdmin(currentUserID string) bool {
 	adminID := config.InstanceAdmin
 	if len(adminID) > 0 {
 		if strings.Contains(adminID, "@") {
-			adminID, _ = db.GetUserIDByEmail(currentUserID)
+			adminID, _ = db.GetUserIDByEmail(adminID)
 		}
 
 		return adminID == currentUserID

--- a/backend/server/auth/handlers.go
+++ b/backend/server/auth/handlers.go
@@ -20,6 +20,7 @@ import (
 func LoginHandler(w http.ResponseWriter, req *http.Request) {
 	var login shared.Login
 	if utils.LimitedJSONReader(w, req.Body).Decode(&login) != nil {
+		log.Printf("Error decoding login request")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -27,9 +28,11 @@ func LoginHandler(w http.ResponseWriter, req *http.Request) {
 	userID, err := ValidateCredentials(login.Identifier, login.LoginKeyHash, login.Code, true)
 	if err != nil {
 		if err == Missing2FAErr {
+			log.Printf("Error: Missing TOTP")
 			http.Error(w, "TOTP required", http.StatusForbidden)
 			return
 		} else if err == Failed2FAErr {
+			log.Printf("Error: Incorrect TOTP")
 			http.Error(w, "TOTP incorrect", http.StatusForbidden)
 			return
 		}
@@ -143,7 +146,7 @@ func AccountHandler(w http.ResponseWriter, req *http.Request, id string) {
 			return
 		}
 
-		err := deleteUser(id, deleteAccount)
+		err := DeleteUser(id, deleteAccount)
 		if err != nil {
 			http.Error(w, "Error deleting account", http.StatusBadRequest)
 			return

--- a/backend/server/html/handlers.go
+++ b/backend/server/html/handlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"yeetfile/backend/config"
 	"yeetfile/backend/db"
+	"yeetfile/backend/server/auth"
 	"yeetfile/backend/server/html/templates"
 	"yeetfile/backend/server/session"
 	"yeetfile/backend/server/upgrades"
@@ -200,7 +201,8 @@ func AccountPageHandler(w http.ResponseWriter, req *http.Request, userID string)
 	hasHint := user.PasswordHint != nil && len(user.PasswordHint) > 0
 	obscuredEmail, _ := utils.ObscureEmail(user.Email)
 	isPrevUpgraded := user.UpgradeExp.Year() >= 2024
-	isAdmin, _ := db.IsUserAdmin(userID)
+
+	isAdmin := auth.IsInstanceAdmin(userID)
 
 	_ = templates.ServeTemplate(
 		w,
@@ -480,13 +482,6 @@ func CheckoutCompleteHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func AdminPageHandler(w http.ResponseWriter, _ *http.Request, id string) {
-	isAdmin, err := db.IsUserAdmin(id)
-	if err != nil || !isAdmin {
-		log.Printf("Error checking admin: %v", err)
-		handleError(w, "User is not an admin", http.StatusUnauthorized)
-		return
-	}
-
 	_ = templates.ServeTemplate(
 		w,
 		templates.AdminHTML,

--- a/backend/server/html/templates/account.html
+++ b/backend/server/html/templates/account.html
@@ -70,6 +70,11 @@
       </tr>
       {{ end }}
     </table>
+    {{ if .IsAdmin }}
+    <a class="no-underline" href="{{ .Base.Endpoints.Admin }}">
+      <button id="admin-btn" class="accent-btn">Admin Console</button>
+    </a><br>
+    {{ end }}
     {{ if or .Base.Config.StripeEnabled .Base.Config.BTCPayEnabled }}
     <a class="no-underline" href="{{ .Base.Endpoints.Upgrade }}">
       <button id="upgrade-btn" class="accent-btn">Upgrade</button>

--- a/backend/server/html/templates/admin.html
+++ b/backend/server/html/templates/admin.html
@@ -1,0 +1,26 @@
+{{ template "head.html" . }}
+<body>
+{{ template "header.html" . }}
+<div id="center-div">
+    <h1>Admin</h1>
+    <hr>
+
+    <h3>User Search</h3>
+    <label for="user-id">User ID or Email:</label>
+    <input type="text" id="user-id" placeholder="user@example.com"><br>
+    <button id="user-search-btn" class="accent-btn">Search Users</button><br>
+    <div id="user-response">
+    </div>
+
+    <hr>
+
+    <h3>File Search</h3>
+    <label for="file-id">File ID:</label>
+    <input type="text" id="file-id" placeholder="file_****..."><br>
+    <button id="file-search-btn" class="accent-btn">Search Files</button>
+    <div id="file-response">
+    </div>
+
+</div>
+{{ template "footer.html" . }}
+</body>

--- a/backend/server/html/templates/templates.go
+++ b/backend/server/html/templates/templates.go
@@ -27,6 +27,7 @@ const (
 	TwoFactorHTML        = "enable_2fa.html"
 	ServerInfoHTML       = "server_info.html"
 	CheckoutCompleteHTML = "checkout_complete.html"
+	AdminHTML            = "admin.html"
 )
 
 //go:embed *.html
@@ -101,6 +102,10 @@ type CheckoutCompleteTemplate struct {
 	Note        string
 }
 
+type AdminTemplate struct {
+	Base BaseTemplate
+}
+
 type AccountTemplate struct {
 	Base              BaseTemplate
 	Email             string
@@ -121,6 +126,7 @@ type AccountTemplate struct {
 	Has2FA            bool
 	ErrorMessage      string
 	SuccessMessage    string
+	IsAdmin           bool
 }
 
 type UpgradeTemplate struct {

--- a/backend/server/middleware.go
+++ b/backend/server/middleware.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 	"yeetfile/backend/config"
-	"yeetfile/backend/db"
+	"yeetfile/backend/server/auth"
 	"yeetfile/backend/server/session"
 	"yeetfile/backend/utils"
 	"yeetfile/shared/constants"
@@ -116,11 +116,8 @@ func AdminMiddleware(next session.HandlerFunc) http.HandlerFunc {
 				return
 			}
 
-			isAdmin, err := db.IsUserAdmin(id)
-			if err != nil {
-				http.Error(w, "Failed to check admin status", http.StatusInternalServerError)
-				return
-			} else if isAdmin {
+			isAdmin := auth.IsInstanceAdmin(id)
+			if isAdmin {
 				// Call the next handler
 				next(w, req, id)
 				return

--- a/backend/server/middleware.go
+++ b/backend/server/middleware.go
@@ -11,7 +11,6 @@ import (
 	"yeetfile/backend/server/auth"
 	"yeetfile/backend/server/session"
 	"yeetfile/backend/utils"
-	"yeetfile/shared/constants"
 	"yeetfile/shared/endpoints"
 )
 
@@ -40,8 +39,8 @@ func getVisitor(identifier string, path string) *rate.Limiter {
 	idHash := blake2b.Sum256([]byte(identifier + path))
 	visitor, exists := visitors[idHash]
 	if !exists {
-		limit := rate.Every(time.Second * constants.LimiterSeconds)
-		limiter := rate.NewLimiter(limit, constants.LimiterAttempts)
+		limit := rate.Every(time.Second * time.Duration(config.YeetFileConfig.LimiterSeconds))
+		limiter := rate.NewLimiter(limit, config.YeetFileConfig.LimiterAttempts)
 		visitors[idHash] = &Visitor{limiter, time.Now()}
 		return limiter
 	}
@@ -174,7 +173,7 @@ func DefaultHeadersMiddleware(next http.HandlerFunc) http.HandlerFunc {
 }
 
 // AuthLimiterMiddleware is like AuthMiddleware, but also restricts requests to
-// the same constants.LimiterAttempts per constants.LimiterSeconds by session
+// the same config.LimiterAttempts per config.LimiterSeconds by session
 // (unlike LimiterMiddleware which limits by IP address)
 func AuthLimiterMiddleware(next session.HandlerFunc) http.HandlerFunc {
 	handler := func(w http.ResponseWriter, req *http.Request) {

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 	"yeetfile/backend/config"
+	"yeetfile/backend/server/admin"
 	"yeetfile/backend/server/auth"
 	"yeetfile/backend/server/html"
 	"yeetfile/backend/server/misc"
@@ -87,6 +88,10 @@ func Run(host, port string) {
 		{POST, endpoints.ChangeHint, AuthMiddleware(auth.ChangeHintHandler)},
 		{PUT, endpoints.RecyclePaymentID, AuthMiddleware(auth.RecyclePaymentIDHandler)},
 
+		// Admin
+		{GET | DELETE, endpoints.AdminUserActions, AdminMiddleware(admin.UserActionHandler)},
+		{GET | DELETE, endpoints.AdminFileActions, AdminMiddleware(admin.FileActionHandler)},
+
 		// Payments (Stripe, BTCPay)
 		{POST, endpoints.StripeWebhook, payments.StripeWebhook},
 		{GET, endpoints.StripeCheckout, StripeMiddleware(AuthMiddleware(payments.StripeCheckout))},
@@ -115,6 +120,7 @@ func Run(host, port string) {
 		{GET, endpoints.HTMLTwoFactor, AuthMiddleware(html.TwoFactorPageHandler)},
 		{GET, endpoints.HTMLServerInfo, html.ServerInfoPageHandler},
 		{GET, endpoints.HTMLCheckoutComplete, html.CheckoutCompleteHandler},
+		{GET, endpoints.HTMLAdmin, AdminMiddleware(html.AdminPageHandler)},
 
 		// Misc
 		{ // Static folder files

--- a/backend/server/transfer/send/handlers.go
+++ b/backend/server/transfer/send/handlers.go
@@ -20,7 +20,7 @@ import (
 
 // UploadMetadataHandler handles a POST request to /u with the metadata required to set
 // up a file for uploading. This is defined in the UploadMetadata struct.
-func UploadMetadataHandler(w http.ResponseWriter, req *http.Request, _ string) {
+func UploadMetadataHandler(w http.ResponseWriter, req *http.Request, userID string) {
 	var meta shared.UploadMetadata
 	data, _ := utils.LimitedReader(w, req.Body)
 	err := json.Unmarshal(data, &meta)
@@ -48,11 +48,16 @@ func UploadMetadataHandler(w http.ResponseWriter, req *http.Request, _ string) {
 		return
 	}
 
-	id, _ := db.InsertMetadata(meta.Chunks, meta.Name, false)
+	id, _ := db.InsertMetadata(meta.Chunks, userID, meta.Name, false)
 	b2Upload := db.CreateNewUpload(id, meta.Name)
 
 	exp := utils.StrToDuration(meta.Expiration, config.IsDebugMode)
-	db.SetFileExpiry(id, meta.Downloads, time.Now().Add(exp).UTC())
+	err = db.SetFileExpiry(id, meta.Downloads, time.Now().Add(exp).UTC())
+	if err != nil {
+		log.Printf("Error setting file expiry: %v\n", err)
+		http.Error(w, "Server error", http.StatusInternalServerError)
+		return
+	}
 
 	var b2Err error
 	if meta.Chunks == 1 {
@@ -143,11 +148,21 @@ func UploadPlaintextHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	id, _ := db.InsertMetadata(1, plaintextUpload.Name, true)
+	id, err := db.InsertMetadata(1, "", plaintextUpload.Name, true)
+	if err != nil {
+		log.Printf("Error inserting new text-only upload metadata: %v\n", err)
+		http.Error(w, "Unable to init metadata", http.StatusInternalServerError)
+		return
+	}
 	b2Upload := db.CreateNewUpload(id, plaintextUpload.Name)
 
 	exp := utils.StrToDuration(plaintextUpload.Expiration, config.IsDebugMode)
-	db.SetFileExpiry(id, plaintextUpload.Downloads, time.Now().Add(exp).UTC())
+	err = db.SetFileExpiry(id, plaintextUpload.Downloads, time.Now().UTC().Add(exp))
+	if err != nil {
+		log.Printf("Error setting file expiry: %v\n", err)
+		http.Error(w, "Server error", http.StatusInternalServerError)
+		return
+	}
 
 	err = transfer.InitB2Upload(b2Upload)
 	if err != nil {

--- a/backend/static/css/admin.css
+++ b/backend/static/css/admin.css
@@ -1,0 +1,8 @@
+code {
+    word-wrap: anywhere;
+}
+
+.span-header {
+    display: block;
+    margin-top: 10px;
+}

--- a/backend/static/css/main.css
+++ b/backend/static/css/main.css
@@ -69,6 +69,13 @@ fieldset {
     display: initial;
 }
 
+.bordered-box {
+    border: 1px solid var(--secondary-text-color);
+    border-radius: 5px;
+    padding: 10px;
+    margin-top: 10px;
+}
+
 .accent-hr {
     color: var(--accent-color) !important;
     background-color: var(--accent-color) !important;

--- a/cli/api/vault_test.go
+++ b/cli/api/vault_test.go
@@ -11,9 +11,9 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"yeetfile/backend/config"
 	"yeetfile/cli/crypto"
 	"yeetfile/shared"
-	"yeetfile/shared/constants"
 	"yeetfile/shared/endpoints"
 )
 
@@ -353,7 +353,7 @@ func TestDownloadLimiter(t *testing.T) {
 	}
 
 	attempt := 1
-	for attempt <= constants.LimiterAttempts {
+	for attempt <= config.YeetFileConfig.LimiterAttempts {
 		err = downloadFunc()
 		assert.Nil(t, err)
 		attempt += 1

--- a/shared/constants/constants.go
+++ b/shared/constants/constants.go
@@ -15,8 +15,6 @@ const (
 	AuthSessionStore                = "auth"
 	Argon2Mem                uint32 = 64 // MB
 	Argon2Iter               uint32 = 2
-	LimiterSeconds                  = 30
-	LimiterAttempts                 = 6
 	TotalBandwidthMultiplier        = 3 // 3x available storage
 	BandwidthMonitorDuration        = 7 // 7 day period
 	IVSize                          = 12
@@ -33,7 +31,4 @@ const (
 	MaxSendAgeDays                  = 30 //days
 	MaxPassNoteLen                  = 500
 	RecoveryCodeLen                 = 8
-
-	DurationMonth UpgradeDuration = "month"
-	DurationYear  UpgradeDuration = "year"
 )

--- a/shared/endpoints/endpoints.go
+++ b/shared/endpoints/endpoints.go
@@ -22,6 +22,7 @@ type HTMLEndpoints struct {
 	VaultFile      string
 	Info           string
 	Upgrade        string
+	Admin          string
 }
 
 type BillingEndpoints struct {
@@ -48,6 +49,9 @@ var (
 	ChangePassword   = Endpoint("/api/change/password")
 	ChangeHint       = Endpoint("/api/change/hint")
 	ServerInfo       = Endpoint("/api/info")
+
+	AdminUserActions = Endpoint("/api/admin/user/*")
+	AdminFileActions = Endpoint("/api/admin/files/*")
 
 	Up = Endpoint("/up")
 
@@ -105,6 +109,7 @@ var (
 	HTMLServerInfo       = Endpoint("/info")
 	HTMLCheckoutComplete = Endpoint("/checkout/complete")
 	HTMLUpgrade          = Endpoint("/upgrade")
+	HTMLAdmin            = Endpoint("/admin")
 )
 
 var JSVarNameMap = map[Endpoint]string{
@@ -123,6 +128,9 @@ var JSVarNameMap = map[Endpoint]string{
 	ChangePassword:   "ChangePassword",
 	ChangeHint:       "ChangeHint",
 	ServerInfo:       "ServerInfo",
+
+	AdminUserActions: "AdminUserActions",
+	AdminFileActions: "AdminFileActions",
 
 	PassRoot:     "PassRoot",
 	PassFolder:   "PassFolder",
@@ -172,6 +180,7 @@ var JSVarNameMap = map[Endpoint]string{
 	HTMLTwoFactor:        "HTMLTwoFactor",
 	HTMLServerInfo:       "HTMLServerInfo",
 	HTMLCheckoutComplete: "HTMLCheckoutComplete",
+	HTMLAdmin:            "HTMLAdmin",
 }
 
 func (e Endpoint) Format(server string, args ...string) string {
@@ -205,6 +214,7 @@ func init() {
 		TwoFactor:      string(HTMLTwoFactor),
 		Info:           string(HTMLServerInfo),
 		Upgrade:        string(HTMLUpgrade),
+		Admin:          string(HTMLAdmin),
 	}
 
 	BillingPageEndpoints = BillingEndpoints{

--- a/shared/structs.go
+++ b/shared/structs.go
@@ -353,3 +353,22 @@ type Upgrades struct {
 	SendUpgrades  []*Upgrade `json:"send_upgrades"`
 	VaultUpgrades []*Upgrade `json:"vault_upgrades"`
 }
+
+type AdminUserInfoResponse struct {
+	ID          string `json:"id"`
+	Email       string `json:"email"`
+	StorageUsed string `json:"storageUsed"`
+	SendUsed    string `json:"sendUsed"`
+
+	Files []AdminFileInfoResponse `json:"files"`
+}
+
+type AdminFileInfoResponse struct {
+	ID         string    `json:"id"`
+	BucketName string    `json:"bucketName"`
+	Size       string    `json:"size"`
+	OwnerID    string    `json:"ownerID"`
+	Modified   time.Time `json:"modified" ts_type:"Date" ts_transform:"new Date(__VALUE__)"`
+
+	RawSize int64
+}

--- a/utils/generate_typescript.go
+++ b/utils/generate_typescript.go
@@ -89,7 +89,9 @@ func main() {
 		Add(shared.NewTOTP{}).
 		Add(shared.SetTOTP{}).
 		Add(shared.SetTOTPResponse{}).
-		Add(shared.ItemIndex{})
+		Add(shared.ItemIndex{}).
+		Add(shared.AdminUserInfoResponse{}).
+		Add(shared.AdminFileInfoResponse{})
 
 	converter.WithBackupDir("")
 	err = converter.ConvertToFile(structsOut)

--- a/web/ts/admin.ts
+++ b/web/ts/admin.ts
@@ -1,0 +1,178 @@
+import {Endpoints} from "./endpoints.js";
+import {AdminFileInfoResponse, AdminUserInfoResponse} from "./interfaces.js";
+
+const init = () => {
+    setupUserSearch();
+    setupFileSearch();
+}
+
+// =============================================================================
+// User admin
+// =============================================================================
+
+const setupUserSearch = () => {
+    let userSearchBtn = document.getElementById("user-search-btn") as HTMLButtonElement;
+    let userIDInput = document.getElementById("user-id") as HTMLInputElement;
+
+    userSearchBtn.addEventListener("click", () => {
+        let userID = userIDInput.value;
+        fetch(Endpoints.format(Endpoints.AdminUserActions, userID)).then(async response => {
+            if (!response.ok) {
+                alert("Error fetching user: " + await response.text());
+                return;
+            }
+
+            let responseDiv = document.getElementById("user-response");
+            responseDiv.innerHTML = "";
+
+            let userInfo = new AdminUserInfoResponse(await response.json());
+            let userDiv = generateUserActionsHTML(userInfo);
+            responseDiv.appendChild(userDiv);
+        }).catch((error: Error) => {
+            alert("Error fetching user");
+            console.error(error);
+        })
+    });
+}
+
+const generateUserActionsHTML = (userInfo: AdminUserInfoResponse): HTMLDivElement => {
+    let userResponseDiv = document.createElement("div") as HTMLDivElement;
+
+    userResponseDiv.className = "bordered-box visible";
+
+    let userInfoElement = document.createElement("code");
+    userInfoElement.innerText = `ID: ${userInfo.id}
+Email: ${userInfo.email}
+Storage Used: ${userInfo.storageUsed}
+Send Used: ${userInfo.sendUsed}`;
+
+    userResponseDiv.appendChild(userInfoElement);
+    userResponseDiv.appendChild(document.createElement("br"));
+
+    let deleteBtnID = `delete-user-${userInfo.id}`;
+    let deleteButton = document.createElement("button");
+    deleteButton.id = deleteBtnID;
+    deleteButton.className = "red-button";
+    deleteButton.innerText = "Delete User and Uploads";
+
+    userResponseDiv.appendChild(deleteButton);
+
+    deleteButton.addEventListener("click", () => {
+        if (!confirm("Deleting this user will also delete all files they have " +
+            "uploaded. Do you wish to proceed?")) {
+            return;
+        }
+
+        fetch(Endpoints.format(Endpoints.AdminUserActions, userInfo.id), {
+            method: "DELETE"
+        }).then(async response => {
+            if (!response.ok) {
+                alert("Failed to delete user! " + await response.text());
+            } else {
+                alert("User and their content has been deleted!");
+                userResponseDiv.innerHTML = "";
+                userResponseDiv.className = "hidden";
+            }
+        }).catch(error => {
+            alert("Failed to delete user");
+            console.error(error);
+        });
+    });
+
+    if (userInfo.files.length > 0) {
+        let header = document.createElement("span");
+        header.className = "span-header";
+        header.innerText = "Files:"
+        userResponseDiv.appendChild(header);
+    }
+
+    for (let i = 0; i < userInfo.files.length; i++) {
+        let fileDiv = generateFileActionsHTML(userInfo.files[i]);
+        userResponseDiv.appendChild(fileDiv);
+    }
+
+    return userResponseDiv;
+}
+
+// =============================================================================
+// File admin
+// =============================================================================
+
+const setupFileSearch = () => {
+    let fileSearchBtn = document.getElementById("file-search-btn") as HTMLButtonElement;
+    let fileIDInput = document.getElementById("file-id") as HTMLInputElement;
+
+    fileSearchBtn.addEventListener("click", () => {
+        let fileID = fileIDInput.value;
+        fetch(Endpoints.format(Endpoints.AdminFileActions, fileID)).then(async response => {
+            if (!response.ok) {
+                alert("Error fetching file: " + await response.text());
+                return
+            }
+
+            let responseDiv = document.getElementById("file-response");
+            responseDiv.innerHTML = "";
+
+            let fileInfo = new AdminFileInfoResponse(await response.json());
+            let fileDiv = generateFileActionsHTML(fileInfo);
+            responseDiv.appendChild(fileDiv);
+        }).catch(error => {
+            console.log(error);
+        })
+    });
+}
+
+const generateFileActionsHTML = (fileInfo: AdminFileInfoResponse): HTMLDivElement => {
+    let fileResponseDiv = document.createElement("div") as HTMLDivElement;
+
+    fileResponseDiv.className = "bordered-box visible";
+
+    let fileInfoElement = document.createElement("code");
+    fileInfoElement.innerText = `ID: ${fileInfo.id}
+Stored Name (encrypted): ${fileInfo.bucketName}
+Size: ${fileInfo.size}
+Owner ID: ${fileInfo.ownerID}
+Modified: ${fileInfo.modified}`;
+
+    fileResponseDiv.appendChild(fileInfoElement);
+    fileResponseDiv.appendChild(document.createElement("br"));
+
+    let deleteBtnID = `delete-file-${fileInfo.id}`;
+    let deleteButton = document.createElement("button");
+    deleteButton.id = deleteBtnID;
+    deleteButton.className = "red-button";
+    deleteButton.innerText = "Delete File";
+
+    fileResponseDiv.appendChild(deleteButton);
+
+    deleteButton.addEventListener("click", () => {
+        if (!confirm("Deleting this file is irreversible. Proceed?")) {
+            return;
+        }
+
+        fetch(Endpoints.format(Endpoints.AdminFileActions, fileInfo.id), {
+            method: "DELETE"
+        }).then(async response => {
+            if (!response.ok) {
+                alert("Failed to delete file! " + await response.text());
+            } else {
+                alert("The file has been deleted!");
+                fileResponseDiv.innerHTML = "";
+                fileResponseDiv.className = "hidden";
+            }
+        }).catch(error => {
+            alert("Failed to delete file");
+            console.error(error);
+        });
+    });
+
+    return fileResponseDiv;
+}
+
+if (document.readyState !== "loading") {
+    init();
+} else {
+    document.addEventListener("DOMContentLoaded", () => {
+        init();
+    });
+}


### PR DESCRIPTION
@FoxxMD

Here is an initial implementation of a web-based admin console. It allows:

- User lookup
- Listing files belonging to a user
- File lookup
- File deletion
- User deletion (which also deletes all files uploaded by the user)

If you have any spare time, I would appreciate your input. It's intended to be a feature that can be expanded upon and refined as the project grows, so it's probably a little rough UI-wise, but it still should provide the necessary content moderation tools for now.

This can be enabled with a new `YEETFILE_INSTANCE_ADMIN` env var that can be set to the maintainer's ID or email for their account.

Here's a preview screenshot showing a user lookup, where the user has one file uploaded, as well as a file lookup for that user's file:

![demo.png](https://github.com/user-attachments/assets/e3dc2af8-57de-4bae-b283-14bfa4673d52)