### PR TITLE
Lockdown mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you need to access the web interface using a machine IP on your network, for 
 generate a cert and set the `YEETFILE_TLS_CERT` and `YEETFILE_TLS_KEY` environment variables (see
 [Environment Variables](#environment-variables))
 
-> [!NOTE]  
+> [!NOTE]
 > This does not apply to the CLI tool. You can still use all features of YeetFile from the CLI tool
 > without a secure connection.
 
@@ -173,7 +173,7 @@ default_view: "vault"
 # debug_file: "~/.config/yeetfile/debug.log"
 ```
 
-You can change the `server` directive to your own instance of YeetFile. 
+You can change the `server` directive to your own instance of YeetFile.
 
 ## Development
 
@@ -235,6 +235,7 @@ All environment variables can be defined in a file named `.env` at the root leve
 | YEETFILE_CACHE_MAX_FILE_SIZE | The maximum file size to cache | 0 | An int value of bytes |
 | YEETFILE_TLS_KEY | The SSL key to use for connections | | The string key contents (not a file path) |
 | YEETFILE_TLS_CERT | The SSL cert to use for connections | | The string cert contents (not a file path) |
+| YEETFILE_LOCKDOWN | Disables anonymous (not logged in) interactions | 0 | `1` to enable lockdown, `0` to allow anonymous usage |
 
 #### Backblaze Environment Variables
 

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -37,6 +37,7 @@ var TLSCert = utils.GetEnvVar("YEETFILE_TLS_CERT", "")
 var TLSKey = utils.GetEnvVar("YEETFILE_TLS_KEY", "")
 
 var IsDebugMode = utils.GetEnvVarBool("YEETFILE_DEBUG", false)
+var IsLockedDown = utils.GetEnvVarBool("YEETFILE_LOCKDOWN", false)
 
 // =============================================================================
 // Email configuration (used in account verification and billing reminders)

--- a/backend/server/html/handlers.go
+++ b/backend/server/html/handlers.go
@@ -86,7 +86,7 @@ func PassVaultPageHandler(w http.ResponseWriter, _ *http.Request, userID string)
 }
 
 // SendPageHandler returns the html template used for sending files
-func SendPageHandler(w http.ResponseWriter, req *http.Request) {
+func SendPageHandler(w http.ResponseWriter, req *http.Request, _ string) {
 	var (
 		sendUsed      int64
 		sendAvailable int64

--- a/backend/server/middleware.go
+++ b/backend/server/middleware.go
@@ -74,6 +74,20 @@ func LimiterMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return handler
 }
 
+// LockdownAuthMiddleware conditionally prevents access to certain pages/actions
+// if the instance is configured to be locked down.
+func LockdownAuthMiddleware(next session.HandlerFunc) http.HandlerFunc {
+	if config.IsLockedDown {
+		return AuthMiddleware(next)
+	}
+
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		next(w, req, "")
+	}
+
+	return handler
+}
+
 // AuthMiddleware enforces that a particular request has a valid session before
 // handling.
 func AuthMiddleware(next session.HandlerFunc) http.HandlerFunc {

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -50,7 +50,7 @@ func Run(host, port string) {
 		// YeetFile Send
 		{POST, endpoints.UploadSendFileMetadata, AuthMiddleware(send.UploadMetadataHandler)},
 		{POST, endpoints.UploadSendFileData, AuthMiddleware(send.UploadDataHandler)},
-		{POST, endpoints.UploadSendText, LimiterMiddleware(send.UploadPlaintextHandler)},
+		{POST, endpoints.UploadSendText, LimiterMiddleware(LockdownAuthMiddleware(send.UploadPlaintextHandler))},
 		{GET, endpoints.DownloadSendFileMetadata, send.DownloadHandler},
 		{GET, endpoints.DownloadSendFileData, send.DownloadChunkHandler},
 
@@ -94,8 +94,8 @@ func Run(host, port string) {
 		{GET, endpoints.BTCPayCheckout, BTCPayMiddleware(AuthMiddleware(payments.BTCPayCheckout))},
 
 		// HTML
-		{GET, endpoints.HTMLHome, html.SendPageHandler},
-		{GET, endpoints.HTMLSend, html.SendPageHandler},
+		{GET, endpoints.HTMLHome, LockdownAuthMiddleware(html.SendPageHandler)},
+		{GET, endpoints.HTMLSend, LockdownAuthMiddleware(html.SendPageHandler)},
 		{GET, endpoints.HTMLPass, AuthMiddleware(html.PassVaultPageHandler)},
 		{GET, endpoints.HTMLPassFolder, AuthMiddleware(html.PassVaultPageHandler)},
 		{GET, endpoints.HTMLPassEntry, AuthMiddleware(html.PassVaultPageHandler)},

--- a/backend/server/transfer/send/handlers.go
+++ b/backend/server/transfer/send/handlers.go
@@ -129,7 +129,7 @@ func UploadDataHandler(w http.ResponseWriter, req *http.Request, userID string) 
 
 // UploadPlaintextHandler handles uploading plaintext with a max size of
 // shared.MaxPlaintextLen characters (constants.go).
-func UploadPlaintextHandler(w http.ResponseWriter, req *http.Request) {
+func UploadPlaintextHandler(w http.ResponseWriter, req *http.Request, _ string) {
 	var plaintextUpload shared.PlaintextUpload
 	err := utils.LimitedJSONReader(w, req.Body).Decode(&plaintextUpload)
 	if err != nil {


### PR DESCRIPTION
Prevents non-authenticated interactions, including text uploads from YF Send.

Use `YEETFILE_LOCKDOWN=1` to enable.

Closes #20 