### PR TITLE
Implement server invite codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ All environment variables can be defined in a file named `.env` at the root leve
 | YEETFILE_LIMITER_ATTEMPTS | The number of attempts to allow before rate limiting | 6 | Any number of requests |
 | YEETFILE_LOCKDOWN | Disables anonymous (not logged in) interactions | 0 | `1` to enable lockdown, `0` to allow anonymous usage |
 | YEETFILE_PROFILING | Enables server profiling on http://localhost:6060 | 0 | `1` to enable, `0` to disable (default) |
+| YEETFILE_ALLOW_INVITES | Allows the YeetFile instance admin to send unique invite codes to email addresses -- must also set `YEETFILE_SERVER_PASSWORD` and setup outgoing email (see [Misc Environment Variables](#misc-environment-variables)) | 0 | `1` to enable, `0` to disable (default) |
 
 #### Backblaze Environment Variables
 

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -48,9 +48,10 @@ var (
 	TLSCert = utils.GetEnvVar("YEETFILE_TLS_CERT", "")
 	TLSKey  = utils.GetEnvVar("YEETFILE_TLS_KEY", "")
 
-	IsDebugMode   = utils.GetEnvVarBool("YEETFILE_DEBUG", false)
-	IsLockedDown  = utils.GetEnvVarBool("YEETFILE_LOCKDOWN", false)
-	InstanceAdmin = utils.GetEnvVar("YEETFILE_INSTANCE_ADMIN", "")
+	IsDebugMode    = utils.GetEnvVarBool("YEETFILE_DEBUG", false)
+	IsLockedDown   = utils.GetEnvVarBool("YEETFILE_LOCKDOWN", false)
+	InstanceAdmin  = utils.GetEnvVar("YEETFILE_INSTANCE_ADMIN", "")
+	InvitesAllowed = utils.GetEnvVarBool("YEETFILE_ALLOW_INVITES", false)
 )
 
 // =============================================================================
@@ -157,6 +158,14 @@ func init() {
 		if err != nil {
 			panic(err)
 		}
+	} else if InvitesAllowed {
+		log.Fatalf("ERROR: You must set YEETFILE_SERVER_PASSWORD if " +
+			"YEETFILE_ALLOW_INVITES is enabled.")
+	}
+
+	if InvitesAllowed && !email.Configured {
+		log.Fatal("ERROR: Email must be configured if " +
+			"YEETFILE_ALLOW_INVITES is enabled.")
 	}
 
 	if slices.Equal(secret, defaultSecret) {

--- a/backend/db/invites.go
+++ b/backend/db/invites.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"fmt"
+	"github.com/lib/pq"
+	"strings"
+)
+
+type Invite struct {
+	Email    string
+	Code     string
+	CodeHash []byte
+}
+
+func AddInviteCodeHashes(inviteCodes []Invite) error {
+	valueStrings := make([]string, 0, len(inviteCodes))
+	valueArgs := make([]interface{}, 0, len(inviteCodes)*2)
+
+	for i, inviteCode := range inviteCodes {
+		valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d)", i*2+1, i*2+2))
+		valueArgs = append(valueArgs, inviteCode.Email)
+		valueArgs = append(valueArgs, inviteCode.CodeHash)
+	}
+
+	stmt := fmt.Sprintf(
+		"INSERT INTO invites (email, code_hash) VALUES %s",
+		strings.Join(valueStrings, ","),
+	)
+
+	_, err := db.Exec(stmt, valueArgs...)
+	return err
+}
+
+func GetInviteCodeHash(email string) ([]byte, error) {
+	var codeHash []byte
+	s := `SELECT code_hash FROM invites WHERE email=$1`
+	err := db.QueryRow(s, email).Scan(&codeHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return codeHash, nil
+}
+
+func GetInvitesList() ([]string, error) {
+	var emails []string
+	s := `SELECT email FROM invites`
+	rows, err := db.Query(s)
+	defer rows.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	for rows.Next() {
+		var email string
+		err = rows.Scan(&email)
+		if err != nil {
+			return nil, err
+		}
+		emails = append(emails, email)
+	}
+
+	return emails, nil
+}
+
+func RemoveInvites(email []string) error {
+	s := `DELETE FROM invites WHERE email=any($1)`
+	_, err := db.Exec(s, pq.Array(email))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/db/scripts/migrations/7_create_invites_table.sql
+++ b/backend/db/scripts/migrations/7_create_invites_table.sql
@@ -1,0 +1,7 @@
+create table if not exists invites
+(
+    email     text  not null
+        constraint invites_pk
+            primary key,
+    code_hash bytea not null
+);

--- a/backend/mail/invite.go
+++ b/backend/mail/invite.go
@@ -1,0 +1,43 @@
+package mail
+
+import (
+	"bytes"
+	"text/template"
+	"yeetfile/shared/endpoints"
+)
+
+type InviteEmail struct {
+	Code     string
+	Email    string
+	Domain   string
+	Endpoint string
+}
+
+var inviteSubject = "YeetFile Invite"
+var inviteBodyTemplate = template.Must(template.New("").Parse(
+	"Hello,\n\nYou have been invited to join a YeetFile instance at this " +
+		"domain: {{.Domain}}\n\n" +
+		"YeetFile is an open source platform that allows encrypted file " +
+		"sharing and storage.\n\n" +
+		"To create an account, you can use the following link:\n\n" +
+		"{{.Domain}}{{.Endpoint}}?email={{.Email}}&code={{.Code}}"))
+
+func SendInviteEmail(code string, to string) error {
+	var buf bytes.Buffer
+
+	inviteEmail := InviteEmail{
+		Code:     code,
+		Email:    to,
+		Domain:   smtpConfig.CallbackDomain,
+		Endpoint: string(endpoints.HTMLSignup),
+	}
+
+	err := inviteBodyTemplate.Execute(&buf, inviteEmail)
+	if err != nil {
+		return err
+	}
+
+	body := buf.String()
+	go sendEmail(to, inviteSubject, body)
+	return nil
+}

--- a/backend/server/admin/handlers.go
+++ b/backend/server/admin/handlers.go
@@ -101,5 +101,28 @@ func FileActionHandler(w http.ResponseWriter, req *http.Request, _ string) {
 
 		_ = json.NewEncoder(w).Encode(fileInfo)
 	}
+}
 
+func InviteActionsHandler(w http.ResponseWriter, req *http.Request, _ string) {
+	var inviteAction shared.AdminInviteAction
+	err := utils.LimitedJSONReader(w, req.Body).Decode(&inviteAction)
+	if err != nil || len(inviteAction.Emails) == 0 {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	switch req.Method {
+	case http.MethodPost:
+		err = createInvites(inviteAction.Emails)
+		if err != nil {
+			http.Error(w, "Error generating invites", http.StatusInternalServerError)
+			return
+		}
+	case http.MethodDelete:
+		err = deleteInvites(inviteAction.Emails)
+		if err != nil {
+			http.Error(w, "Error deleting invites", http.StatusInternalServerError)
+			return
+		}
+	}
 }

--- a/backend/server/admin/invite_actions.go
+++ b/backend/server/admin/invite_actions.go
@@ -1,0 +1,53 @@
+package admin
+
+import (
+	"golang.org/x/crypto/bcrypt"
+	"log"
+	"yeetfile/backend/db"
+	"yeetfile/backend/mail"
+	"yeetfile/shared"
+)
+
+func createInvites(emails []string) error {
+	var invites []db.Invite
+	for _, email := range emails {
+		code := shared.GenRandomString(12)
+		codeHash, err := bcrypt.GenerateFromPassword([]byte(code), 8)
+		if err != nil {
+			log.Printf("Error generating invite code: %v\n", err)
+			return err
+		}
+
+		invite := db.Invite{
+			Email:    email,
+			Code:     code,
+			CodeHash: codeHash,
+		}
+
+		invites = append(invites, invite)
+	}
+
+	err := db.AddInviteCodeHashes(invites)
+	if err != nil {
+		return err
+	}
+
+	for _, invite := range invites {
+		err = mail.SendInviteEmail(invite.Code, invite.Email)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteInvites(emails []string) error {
+	err := db.RemoveInvites(emails)
+	if err != nil {
+		log.Printf("Error deleting invites: %v\n", err)
+		return err
+	}
+
+	return nil
+}

--- a/backend/server/html/templates/admin.html
+++ b/backend/server/html/templates/admin.html
@@ -5,6 +5,31 @@
     <h1>Admin</h1>
     <hr>
 
+    {{ if .InvitesAllowed }}
+    <h3>Invites</h3>
+    {{ if .PendingInvites }}
+    <div>
+        <label for="pending-invites">Pending Invites:</label><br>
+        <select id="pending-invites" multiple size="10">
+            {{ range $val := .PendingInvites }}
+            <option value="{{$val}}">{{$val}}</option>
+            {{ end }}
+        </select>
+        <br>
+        <button id="revoke-invites" class="red-button">Revoke Selected Invites</button>
+    </div>
+    <hr class="half-hr">
+    {{ end }}
+
+    <div>
+        <label for="invite-emails">Insert a comma-separated list of emails to invite:</label><br>
+        <textarea id="invite-emails"></textarea>
+        <br>
+        <button id="send-invites" class="accent-btn">Send Invites</button>
+    </div>
+    <hr>
+    {{ end }}
+
     <h3>User Search</h3>
     <label for="user-id">User ID or Email:</label>
     <input type="text" id="user-id" placeholder="user@example.com"><br>

--- a/backend/server/html/templates/signup.html
+++ b/backend/server/html/templates/signup.html
@@ -16,7 +16,9 @@
             <label for="id-signup">Account ID Only</label><br>
             <hr>
         </div>
-        {{ if .ServerPasswordRequired }}
+        {{ if .InviteCode }}
+            <input type="password" id="server-password" placeholder="Server Password" hidden value="{{.InviteCode}}">
+        {{ else if .ServerPasswordRequired }}
         <div class="padding-left-3">
             <span class="red-text">This server is password protected!</span><br>
             <span>Please enter the server password below to create an account.</span>
@@ -34,7 +36,11 @@
             <table>
                 <tr>
                     <td><label for="email">Email Address:</label></td>
+                    {{ if .InviteEmail }}
+                    <td><input type="text" id="email" name="email" placeholder="Email Address" value="{{.InviteEmail}}" disabled></td>
+                    {{ else }}
                     <td><input type="text" id="email" name="email" placeholder="Email Address"></td>
+                    {{ end }}
                 </tr>
                 <tr>
                     <td><label for="password">Password <span class="small-text">(min 8 chars)</span>:</label></td>

--- a/backend/server/html/templates/templates.go
+++ b/backend/server/html/templates/templates.go
@@ -55,6 +55,8 @@ type SignupTemplate struct {
 	Base                   BaseTemplate
 	ServerPasswordRequired bool
 	EmailConfigured        bool
+	InviteEmail            string
+	InviteCode             string
 }
 
 type LoginTemplate struct {
@@ -106,7 +108,9 @@ type CheckoutCompleteTemplate struct {
 }
 
 type AdminTemplate struct {
-	Base BaseTemplate
+	Base           BaseTemplate
+	InvitesAllowed bool
+	PendingInvites []string
 }
 
 type AccountTemplate struct {

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -93,6 +93,7 @@ func Run(host, port string) {
 		// Admin
 		{GET | PUT | DELETE, endpoints.AdminUserActions, AdminMiddleware(admin.UserActionHandler)},
 		{GET | DELETE, endpoints.AdminFileActions, AdminMiddleware(admin.FileActionHandler)},
+		{POST | DELETE, endpoints.AdminInviteActions, AdminMiddleware(admin.InviteActionsHandler)},
 
 		// Payments (Stripe, BTCPay)
 		{POST, endpoints.StripeWebhook, payments.StripeWebhook},

--- a/backend/static/css/admin.css
+++ b/backend/static/css/admin.css
@@ -6,3 +6,7 @@ code {
     display: block;
     margin-top: 10px;
 }
+
+#pending-invites, #invite-emails {
+    min-width: 350px;
+}

--- a/shared/endpoints/endpoints.go
+++ b/shared/endpoints/endpoints.go
@@ -50,8 +50,9 @@ var (
 	ChangeHint       = Endpoint("/api/change/hint")
 	ServerInfo       = Endpoint("/api/info")
 
-	AdminUserActions = Endpoint("/api/admin/user/*")
-	AdminFileActions = Endpoint("/api/admin/files/*")
+	AdminUserActions   = Endpoint("/api/admin/user/*")
+	AdminFileActions   = Endpoint("/api/admin/files/*")
+	AdminInviteActions = Endpoint("/api/admin/invites")
 
 	Up = Endpoint("/up")
 
@@ -129,8 +130,9 @@ var JSVarNameMap = map[Endpoint]string{
 	ChangeHint:       "ChangeHint",
 	ServerInfo:       "ServerInfo",
 
-	AdminUserActions: "AdminUserActions",
-	AdminFileActions: "AdminFileActions",
+	AdminUserActions:   "AdminUserActions",
+	AdminFileActions:   "AdminFileActions",
+	AdminInviteActions: "AdminInviteActions",
 
 	PassRoot:     "PassRoot",
 	PassFolder:   "PassFolder",

--- a/shared/structs.go
+++ b/shared/structs.go
@@ -382,3 +382,7 @@ type AdminFileInfoResponse struct {
 
 	RawSize int64
 }
+
+type AdminInviteAction struct {
+	Emails []string `json:"emails"`
+}

--- a/utils/generate_typescript.go
+++ b/utils/generate_typescript.go
@@ -93,6 +93,7 @@ func main() {
 		Add(shared.AdminUserInfoResponse{}).
 		Add(shared.AdminUserAction{}).
 		Add(shared.AdminFileInfoResponse{}).
+		Add(shared.AdminInviteAction{}).
 		Add(shared.ServerInfo{})
 
 	converter.WithBackupDir("")

--- a/web/ts/admin.ts
+++ b/web/ts/admin.ts
@@ -1,6 +1,7 @@
 import {Endpoints} from "./endpoints.js";
 import {
     AdminFileInfoResponse,
+    AdminInviteAction,
     AdminUserAction,
     AdminUserInfoResponse
 } from "./interfaces.js";
@@ -8,6 +9,69 @@ import {
 const init = () => {
     setupUserSearch();
     setupFileSearch();
+    setupInviteSending();
+    setupInviteRevoking();
+}
+
+// =============================================================================
+// Invite actions
+// =============================================================================
+const setupInviteSending = () => {
+    let inviteList = document.getElementById("invite-emails") as HTMLTextAreaElement;
+    if (!inviteList) {
+        // Invites not enabled by the server admin
+        return;
+    }
+
+    let sendInvitesBtn = document.getElementById("send-invites");
+    sendInvitesBtn.addEventListener("click", () => {
+        let invitesText = inviteList.value.replace(" ", "");
+        let invitesList = invitesText.split(",");
+        let invites = new AdminInviteAction();
+        invites.emails = invitesList;
+
+        fetch(Endpoints.AdminInviteActions.path, {
+            method: "POST",
+            body: JSON.stringify(invites)
+        }).then(async response => {
+            if (!response.ok) {
+                alert("Error sending invites: " + await response.text());
+                return;
+            }
+
+            alert("Invite(s) sent!");
+            window.location.reload();
+        });
+    });
+}
+
+const setupInviteRevoking = () => {
+    let pendingInvites = document.getElementById("pending-invites") as HTMLSelectElement;
+    if (!pendingInvites) {
+        // Invites not enabled by the server admin
+        return;
+    }
+
+    let revokeInvitesBtn = document.getElementById("revoke-invites");
+    revokeInvitesBtn.addEventListener("click", () => {
+        let selectedValues = Array.from(pendingInvites.selectedOptions)
+            .map(option => option.value);
+        let invites = new AdminInviteAction();
+        invites.emails = selectedValues;
+
+        fetch(Endpoints.AdminInviteActions.path, {
+            method: "DELETE",
+            body: JSON.stringify(invites)
+        }).then(async response => {
+            if (!response.ok) {
+                alert("Failed to revoke pending invites: " + await response.text());
+                return;
+            }
+
+            alert("Invite(s) revoked!");
+            window.location.reload();
+        });
+    });
 }
 
 // =============================================================================


### PR DESCRIPTION
This introduces the ability for a YeetFile instance admin to send out invites to a list of emails with unique signup codes. These signup codes are tied to the email they're sent to, and are removed after a user completes registration using that email and signup code. The code a user receives cannot be used to sign up for an ID-only account, and cannot be used to sign up with a different email address.

The invite codes are not stored in plaintext anywhere. They are hashed with bcrypt before storing in the database, and are only included in plaintext in the outbound email. When a user clicks the signup link in the email they received, the code is used to autofill the server password field, and does not require any further interaction from the user.

Enabling invite codes requires the following conditions:

- `YEETFILE_ALLOW_INVITES` set to `1`
- `YEETFILE_SERVER_PASSWORD` set to a non-empty string
  - This is required to prevent unauthorized signups (verification codes are treated as a fallback method for validating the server password)
- `YEETFILE_EMAIL_*` variables set
  - This is required since invite codes have to be emailed to recipients
- `YEETFILE_INSTANCE_ADMIN` set to the email address or account ID for the preferred admin user

Closes #36 